### PR TITLE
Add compatibility for multiple nodes argument to use dash separator

### DIFF
--- a/traffic.py
+++ b/traffic.py
@@ -1,13 +1,12 @@
 import requests
 import time
 import datetime
-import json
 import os
 import base64
-import sys
 import urllib.parse
 import requests
 import argparse
+import re
 
 def send_waku_msg(node_address, kbytes, pubsub_topic, content_topic):
     # TODO dirty trick .replace("=", "")
@@ -67,19 +66,19 @@ if args.single_node != None:
 # [http://url-1:port
 nodes = []
 if args.multiple_nodes:
-  #if args.multiple_nodes contain underscore then split by underscore else split by hyphen
-  if "_" in args.multiple_nodes:
-    range_nodes = args.multiple_nodes.split(":")[1].split("_")[2]
+  match = re.search(r'\[(\d+)\.\.(\d+)\]', args.multiple_nodes)
+  if match:
+      start = int(match.group(1))
+      end = int(match.group(2))
   else:
-    range_nodes = args.multiple_nodes.split(":")[1].split("-")[-1]
-  node_placeholder = args.multiple_nodes.replace(range_nodes, "{placeholder}")
-  clean_range = range_nodes.replace("[", "").replace("]", "")
-  start = int(clean_range.split("..")[0])
-  end = int(clean_range.split("..")[1])
+      print("Could not parse range of multiple_nodes argument")
+      exit
 
   print("Injecting traffic to multiple nodes REST APIs") 
   for i in range(start, end+1):
-    nodes.append(node_placeholder.replace("{placeholder}", str(i)))
+      range_start = args.multiple_nodes.index("[")
+      range_end = args.multiple_nodes.index("]")
+      nodes.append(args.multiple_nodes[:range_start] + str(i) + args.multiple_nodes[range_end+1:])
 
 for node in nodes:
   print(node)

--- a/traffic.py
+++ b/traffic.py
@@ -66,19 +66,15 @@ if args.single_node != None:
 # [http://url-1:port
 nodes = []
 if args.multiple_nodes:
-  match = re.search(r'\[(\d+)\.\.(\d+)\]', args.multiple_nodes)
-  if match:
-      start = int(match.group(1))
-      end = int(match.group(2))
-  else:
+  start, end = (int(x) for x in re.search(r"\[(\d+)\.\.(\d+)\]", args.multiple_nodes).groups()) 
+ 
+  if start is None or end is None:
       print("Could not parse range of multiple_nodes argument")
       exit
 
   print("Injecting traffic to multiple nodes REST APIs") 
-  for i in range(start, end+1):
-      range_start = args.multiple_nodes.index("[")
-      range_end = args.multiple_nodes.index("]")
-      nodes.append(args.multiple_nodes[:range_start] + str(i) + args.multiple_nodes[range_end+1:])
+  for i in range(end, start - 1, -1): 
+    nodes.append(re.sub(r"\[\d+\.\.\d+\]", str(i), args.multiple_nodes))
 
 for node in nodes:
   print(node)

--- a/traffic.py
+++ b/traffic.py
@@ -47,8 +47,8 @@ parser = argparse.ArgumentParser(description='')
 
 # these flags are mutually exclusive, one or the other, never at once
 group = parser.add_mutually_exclusive_group(required=True)
-group.add_argument('-sn', '--single-node', type=str, help='example: http://waku-simulator_nwaku_1:8645')
-group.add_argument('-mn', '--multiple-nodes', type=str, help='example: http://waku-simulator_nwaku_[1..10]:8645')
+group.add_argument('-sn', '--single-node', type=str, help='example: http://waku-simulator-nwaku-1:8645')
+group.add_argument('-mn', '--multiple-nodes', type=str, help='example: http://waku-simulator-nwaku-[1..10]:8645')
 
 # rest of araguments
 parser.add_argument('-c', '--content-topic', type=str, help='content topic', default="my-ctopic")
@@ -63,10 +63,15 @@ if args.single_node != None:
   print("Injecting traffic to single node REST API:", args.single_node)
 
 # this simply converts from http://url_[1..5]:port to
-# [http://url_1:port
+# [http://url_1:port or from http://url-[1..5]:port to
+# [http://url-1:port
 nodes = []
 if args.multiple_nodes:
-  range_nodes = args.multiple_nodes.split(":")[1].split("_")[2]
+  #if args.multiple_nodes contain underscore then split by underscore else split by hyphen
+  if "_" in args.multiple_nodes:
+    range_nodes = args.multiple_nodes.split(":")[1].split("_")[2]
+  else:
+    range_nodes = args.multiple_nodes.split(":")[1].split("-")[-1]
   node_placeholder = args.multiple_nodes.replace(range_nodes, "{placeholder}")
   clean_range = range_nodes.replace("[", "").replace("]", "")
   start = int(clean_range.split("..")[0])


### PR DESCRIPTION
This PR partially solves this issue https://github.com/waku-org/waku-simulator/issues/89 and needs to be merged before this PR https://github.com/waku-org/waku-simulator/pull/90
It allows for container names  passed as the `--multiple-nodes` argument to either use the underscore or dash as name separator.